### PR TITLE
[FEAT] 애플 로그인 작업

### DIFF
--- a/src/components/auth/apple/index.tsx
+++ b/src/components/auth/apple/index.tsx
@@ -21,7 +21,7 @@ function AppleLogin() {
     );
 
     if (credentialState === appleAuth.State.AUTHORIZED) {
-      setAppleUser(appleAuthRequestResponse.user);
+      setAppleUser(appleAuthRequestResponse.authorizationCode!);
       setUser({
         ...user,
         type: 'APPLE',

--- a/src/components/auth/apple/index.tsx
+++ b/src/components/auth/apple/index.tsx
@@ -5,7 +5,7 @@ import Typography from '../../typography';
 import appleLoginStyle from './AppleLogin.style';
 import useUserMutation from '@/hooks/mutaions/useUserMutation';
 import {useUserStore} from '@/stores/user';
-import {showSnackBar} from '@/utils/showSnackBar';
+import {setAppleUser} from '@/services/localStorage/localStorage';
 
 function AppleLogin() {
   const {loginMutate} = useUserMutation();
@@ -21,10 +21,7 @@ function AppleLogin() {
     );
 
     if (credentialState === appleAuth.State.AUTHORIZED) {
-      if (appleAuthRequestResponse.email === null) {
-        showSnackBar('"설정 > Apple ID 사용 중단" 후 시도해 주세요');
-        return;
-      }
+      setAppleUser(appleAuthRequestResponse.user);
       setUser({
         ...user,
         type: 'APPLE',

--- a/src/components/auth/apple/index.tsx
+++ b/src/components/auth/apple/index.tsx
@@ -9,7 +9,7 @@ import {setAppleUser} from '@/services/localStorage/localStorage';
 
 function AppleLogin() {
   const {loginMutate} = useUserMutation();
-  const {user, setUser} = useUserStore();
+  const {user, setUser, setIdToken} = useUserStore();
   async function handleSignInApple() {
     const appleAuthRequestResponse = await appleAuth.performRequest({
       requestedOperation: appleAuth.Operation.LOGIN,
@@ -34,6 +34,7 @@ function AppleLogin() {
         type: 'APPLE',
         token: appleAuthRequestResponse.identityToken!,
       });
+      setIdToken(appleAuthRequestResponse.identityToken!);
     }
   }
 

--- a/src/components/auth/kakao/index.tsx
+++ b/src/components/auth/kakao/index.tsx
@@ -8,7 +8,7 @@ import kakaoLoginStyles from './KakaoLogin.style';
 import useUserMutation from '@/hooks/mutaions/useUserMutation';
 
 function KakaoLogin() {
-  const {setUser, user} = useUserStore();
+  const {user, setUser, setIdToken} = useUserStore();
   const {loginMutate} = useUserMutation();
 
   // 카카오 로그인 함수
@@ -25,6 +25,7 @@ function KakaoLogin() {
       type: 'KAKAO',
       token: res.idToken,
     });
+    setIdToken(res.idToken);
   };
 
   return (

--- a/src/hooks/mutaions/useUserMutation.ts
+++ b/src/hooks/mutaions/useUserMutation.ts
@@ -46,7 +46,6 @@ const useUserMutation = () => {
       postRegisterUser(sendData.type, sendData.idToken, sendData.body),
     onSuccess: data => {
       console.log('회원가입 성공');
-      loginMutate({type: user.type, token: data.data.accessToken});
       console.log(data);
       stackNavigation.navigate(stackScreens.SignupCompleteScreen);
     },
@@ -66,7 +65,7 @@ const useUserMutation = () => {
   const quitUser = useMutation({
     mutationFn: deleteUser,
     onSuccess: async () => {
-      stackNavigation.navigate(stackScreens.LoginScreen);
+      stackNavigation.popToTop();
       showSnackBar('정상적으로 계정 탈퇴되었어요');
       await removeTokens();
     },

--- a/src/hooks/mutaions/useUserMutation.ts
+++ b/src/hooks/mutaions/useUserMutation.ts
@@ -21,6 +21,10 @@ const useUserMutation = () => {
   const {mutate: loginMutate} = useMutation({
     mutationFn: postLoginUser,
     onSuccess: login => {
+      if (user.email === null) {
+        showSnackBar('"설정 > Apple ID 사용 중단" 후 시도해 주세요');
+        return;
+      }
       setUser({...user, isLookAround: false});
       if (!login.data.canLogin) {
         stackNavigation.navigate(stackScreens.SignupScreen, {

--- a/src/hooks/mutaions/useUserMutation.ts
+++ b/src/hooks/mutaions/useUserMutation.ts
@@ -7,7 +7,10 @@ import {
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import useNavigator from '../useNavigator';
 import stackScreens from '@/constants/stackScreens';
-import {setIsInstalled} from '@/services/localStorage/localStorage';
+import {
+  removeTokens,
+  setIsInstalled,
+} from '@/services/localStorage/localStorage';
 import {IRegisterMutationProps} from '@/types/user';
 import {useUserStore} from '@/stores/user';
 import {showSnackBar} from '@/utils/showSnackBar';
@@ -53,17 +56,19 @@ const useUserMutation = () => {
   const logoutUser = useMutation({
     mutationFn: postLogoutUser,
 
-    onSuccess: () => {
+    onSuccess: async () => {
       stackNavigation.navigate(stackScreens.LoginScreen);
       showSnackBar('정상적으로 로그아웃 되었어요');
+      await removeTokens();
     },
   });
 
   const quitUser = useMutation({
     mutationFn: deleteUser,
-    onSuccess: () => {
+    onSuccess: async () => {
       stackNavigation.navigate(stackScreens.LoginScreen);
       showSnackBar('정상적으로 계정 탈퇴되었어요');
+      await removeTokens();
     },
   });
 

--- a/src/hooks/mutaions/useUserMutation.ts
+++ b/src/hooks/mutaions/useUserMutation.ts
@@ -21,12 +21,12 @@ const useUserMutation = () => {
   const {mutate: loginMutate} = useMutation({
     mutationFn: postLoginUser,
     onSuccess: login => {
-      if (user.email === null) {
-        showSnackBar('"설정 > Apple ID 사용 중단" 후 시도해 주세요');
-        return;
-      }
       setUser({...user, isLookAround: false});
       if (!login.data.canLogin) {
+        if (user.email === null) {
+          showSnackBar('"설정 > Apple ID 사용 중단" 후 시도해 주세요');
+          return;
+        }
         stackNavigation.navigate(stackScreens.SignupScreen, {
           idToken: login.data.idToken,
         });

--- a/src/screens/myPage/setting/SettingScreen.tsx
+++ b/src/screens/myPage/setting/SettingScreen.tsx
@@ -13,7 +13,7 @@ import Typography from '@/components/typography';
 import palette from '@/styles/theme/color';
 import stackScreens from '@/constants/stackScreens';
 import Popup from '@/components/popup';
-import {removeTokens, setIsAlarm} from '@/services/localStorage/localStorage';
+import {setIsAlarm} from '@/services/localStorage/localStorage';
 import {checkAlarmPermission} from '@/services/permissionService';
 import useUserMutation from '@/hooks/mutaions/useUserMutation';
 
@@ -84,7 +84,6 @@ const SettingScreen = () => {
     onCloseModal();
     // 로그아웃 api 실행
     logoutUser.mutate();
-    await removeTokens();
   };
 
   return (

--- a/src/screens/myPage/setting/screens/withdraw/WithdrawScreen.tsx
+++ b/src/screens/myPage/setting/screens/withdraw/WithdrawScreen.tsx
@@ -9,7 +9,7 @@ import SubTitleDescription from '@/components/title/subTitleDescription';
 import TitleCenterTopBar from '@/components/topBar/titleCenterTopBar';
 import useNavigator from '@/hooks/useNavigator';
 import {TKorQuitReason, korQuitReason} from '@/models/enums/user';
-import {removeTokens} from '@/services/localStorage/localStorage';
+import {getAppleUser} from '@/services/localStorage/localStorage';
 import {getQuitReason} from '@/utils/getQuitReason';
 import useUserMutation from '@/hooks/mutaions/useUserMutation';
 
@@ -28,9 +28,12 @@ const WithdrawScreen = () => {
     onCloseModal();
 
     if (quitReason) {
-      quitUser.mutate({appleCode: '', quitReason: getQuitReason(quitReason)});
+      const appleCode = await getAppleUser();
+      quitUser.mutate({
+        appleCode: appleCode || '',
+        quitReason: getQuitReason(quitReason),
+      });
     }
-    await removeTokens();
   };
   return (
     <>

--- a/src/screens/signupComplete/SIgnupCompleteScreen.tsx
+++ b/src/screens/signupComplete/SIgnupCompleteScreen.tsx
@@ -3,10 +3,10 @@ import signupCompleteScreenContainerStyles from './SignupCompleteScreen.style';
 import {getScreenSize} from '@/utils/getScreenSize';
 import {Image, View} from 'react-native';
 import {defaultImages} from '@/assets';
-import CancelTopBar from '@/components/topBar/cancelTopBar';
 import SubTitleDescription from '@/components/title/subTitleDescription';
-import useNavigator from '@/hooks/useNavigator';
 import BoxButton from '@/components/buttons/boxButton';
+import useUserMutation from '@/hooks/mutaions/useUserMutation';
+import {useUserStore} from '@/stores/user';
 
 const SignupCompleteScreen = () => {
   const {top, bottom} = useSafeAreaInsets();
@@ -17,7 +17,11 @@ const SignupCompleteScreen = () => {
     width,
     height,
   });
-  const {stackNavigation} = useNavigator();
+  const {loginMutate} = useUserMutation();
+  const {user, idToken} = useUserStore();
+
+  const startPopcornMate = async () =>
+    loginMutate({type: user.type, token: idToken});
 
   return (
     <View style={style.container}>
@@ -25,15 +29,12 @@ const SignupCompleteScreen = () => {
         <Image source={defaultImages.pacong} style={style.pacong} />
       </View>
       <Image source={defaultImages.completeSignupPopcorn} style={style.image} />
-      <CancelTopBar onPress={() => stackNavigation.popToTop()} text="" />
       <View style={style.innerWrap}>
         <SubTitleDescription
           text="회원가입이 끝났습니다!"
           subTitle="팝콘메이트에 오신걸 환영합니다!"
         />
-        <BoxButton onPress={() => stackNavigation.popToTop()}>
-          팝콘메이트 시작하기
-        </BoxButton>
+        <BoxButton onPress={startPopcornMate}>팝콘메이트 시작하기</BoxButton>
       </View>
     </View>
   );

--- a/src/services/localStorage/localStorage.ts
+++ b/src/services/localStorage/localStorage.ts
@@ -81,3 +81,14 @@ export const getIsAlarm = async (): Promise<boolean | null> => {
 export const removeAlarm = async () => {
   await setIsAlarm(null);
 };
+
+// 애플 로그인 시 유저 정보 저장
+export const setAppleUser = async (user: string) => {
+  await setItem<string>(LocalStorageKey.AppleUser, user);
+};
+
+// 애플 유저 정보 가져옴
+export const getAppleUser = async (): Promise<string | null> => {
+  const appleUser = await getItemOrNull<string>(LocalStorageKey.AppleUser);
+  return appleUser;
+};

--- a/src/services/localStorage/localStorage.ts
+++ b/src/services/localStorage/localStorage.ts
@@ -52,8 +52,7 @@ export const setTokens = async (refresh: string, access: string) => {
 
 // 로그아웃 혹은 탈퇴 토큰 제거
 export const removeTokens = async () => {
-  await setRefreshToken('');
-  await setAccessToken('');
+  await EncryptedStorage.clear();
 };
 
 // 회원가입을 해야 할 최초 유저 여부 가져옴
@@ -83,8 +82,8 @@ export const removeAlarm = async () => {
 };
 
 // 애플 로그인 시 유저 정보 저장
-export const setAppleUser = async (user: string) => {
-  await setItem<string>(LocalStorageKey.AppleUser, user);
+export const setAppleUser = async (authorizationCode: string) => {
+  await setItem<string>(LocalStorageKey.AppleUser, authorizationCode);
 };
 
 // 애플 유저 정보 가져옴

--- a/src/services/localStorage/localStorageKey.ts
+++ b/src/services/localStorage/localStorageKey.ts
@@ -3,5 +3,6 @@ const enum LocalStorageKey {
   AccessToken = 'AccessToken',
   IsInstalled = 'IsInstalled',
   IsAlarm = 'IsAlarm',
+  AppleUser = 'AppleUser',
 }
 export default LocalStorageKey;

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -11,9 +11,11 @@ interface IUser {
 
 interface IUserStoreState {
   user: IUser;
+  idToken: string;
 }
 interface IUserStoreActions {
   setUser: (state: IUser) => void;
+  setIdToken: (state: string) => void;
 }
 
 export const useUserStore = create<IUserStoreState & IUserStoreActions>(
@@ -26,6 +28,8 @@ export const useUserStore = create<IUserStoreState & IUserStoreActions>(
       name: '',
       isLookAround: false,
     },
+    idToken: '',
     setUser: (state: IUser) => set({user: state}),
+    setIdToken: (state: string) => set({idToken: state}),
   }),
 );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 버그 수정
- [x] 기능 구현
- [ ] 성능 관련 작업
- [ ] 리팩토링
- [ ] UI 작업

### 반영 브랜치
feat/#138 -> develop

### 변경 사항
- 애플 로그인 시 appleCode storage에 저장하기
- 로그인 요청 시 회원가입 해야하는 상태이고 email이 null로 반환될 때 이벤트 관리
- 애플 탈퇴하기 연동하기
- 회원가입 완료 시 스크리닝 홈으로 이동
